### PR TITLE
feat(security): comprehensive security hardening

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -282,6 +282,13 @@ jobs:
             fi
           done
       
+      - name: Install and configure Fail2Ban
+        working-directory: deployment/ansible
+        env:
+          ANSIBLE_HOST_KEY_CHECKING: False
+        run: |
+          ansible-playbook -i inventory/production.yml playbooks/setup_fail2ban.yml -v
+
       - name: Verify Swarm Status
         uses: appleboy/ssh-action@v1.0.0
         with:

--- a/deployment/ansible/inventory/inventory.tpl
+++ b/deployment/ansible/inventory/inventory.tpl
@@ -1,25 +1,31 @@
 all:
   children:
-    swarm_managers: # Changed 'manager' to 'swarm_managers' here
+    swarm_managers:
       hosts:
         turbogate-manager:
-          ansible_host: "${manager_ip}"  # Will be replaced by Terraform output
-          ansible_user: root
+          ansible_host: "${manager_ip}"
+          ansible_user: "${ssh_user}"
           internal_ip: 10.0.1.10
-          
     workers:
       hosts:
         turbogate-worker-1:
-          ansible_host: "${worker_1_ip}"  # Will be replaced by Terraform output
-          ansible_user: root
+          ansible_host: "${worker_1_ip}"
+          ansible_user: "${ssh_user}"
           internal_ip: 10.0.1.11
-          
         turbogate-worker-2:
-          ansible_host: "${worker_2_ip}"  # Will be replaced by Terraform output
-          ansible_user: root
+          ansible_host: "${worker_2_ip}"
+          ansible_user: "${ssh_user}"
           internal_ip: 10.0.1.12
-          
+    bastion:
+      hosts:
+        turbogate-bastion:
+          ansible_host: "${bastion_ip}"
+          ansible_user: "${ssh_user}"
   vars:
-    ansible_ssh_common_args: '-o StrictHostKeyChecking=no'
+    ansible_ssh_common_args: >-
+      -o StrictHostKeyChecking=no
+      %{ if bastion_ip != "" }
+      -o ProxyJump=${ssh_user}@${bastion_ip}
+      %{ endif }
     ansible_python_interpreter: /usr/bin/python3
-    floating_ip: "${floating_ip}"  # Add floating IP to vars
+    floating_ip: "${floating_ip}"

--- a/deployment/ansible/playbooks/setup_fail2ban.yml
+++ b/deployment/ansible/playbooks/setup_fail2ban.yml
@@ -1,0 +1,39 @@
+---
+- name: Install and Configure Fail2Ban
+  hosts: all
+  become: yes
+
+  tasks:
+    - name: Install Fail2Ban
+      ansible.builtin.apt:
+        name: fail2ban
+        state: present
+        update_cache: yes
+
+    - name: Create Fail2Ban jail.local for SSH and NGINX
+      ansible.builtin.copy:
+        dest: /etc/fail2ban/jail.local
+        content: |
+          [DEFAULT]
+          bantime = 1h
+          findtime = 10m
+          maxretry = 5
+
+          [sshd]
+          enabled = true
+
+          [nginx-http-auth]
+          enabled = true
+
+          [nginx-dos]
+          enabled = true
+        owner: root
+        group: root
+        mode: '0644'
+      notify: Restart Fail2Ban
+
+  handlers:
+    - name: Restart Fail2Ban
+      ansible.builtin.systemd:
+        name: fail2ban
+        state: restarted

--- a/deployment/ansible/playbooks/templates/nginx.conf.j2
+++ b/deployment/ansible/playbooks/templates/nginx.conf.j2
@@ -1,3 +1,6 @@
+# Hide NGINX version
+server_tokens off;
+
 # Dynamic upstream resolution - no static upstream blocks
 resolver 127.0.0.11 valid=30s ipv6=off;
 

--- a/deployment/terraform/main.tf
+++ b/deployment/terraform/main.tf
@@ -1,3 +1,12 @@
+data "http" "github_meta" {
+  url = "https://api.github.com/meta"
+}
+
+locals {
+  github_meta = jsondecode(data.http.github_meta.response_body)
+  github_actions_ips = local.github_meta.actions
+}
+
 provider "hcloud" {
   token = var.hcloud_token
 }
@@ -21,17 +30,21 @@ resource "hcloud_network_subnet" "main" {
   ip_range     = "10.0.1.0/24"
 }
 
-# Firewall - Enhanced for Docker Swarm
+# ===== SECURITY HARDENED FIREWALL =====
+# CHANGED: Added restrictive rules, egress controls, and IP allowlisting
 resource "hcloud_firewall" "main" {
   name = "turbogate-firewall"
   
+  # CHANGED: SSH restricted to admin IPs only (no longer 0.0.0.0/0)
   rule {
     direction  = "in"
     protocol   = "tcp"
     port       = "22"
-    source_ips = ["0.0.0.0/0", "::/0"]
+    source_ips = concat(var.admin_ips, local.github_actions_ips)
+    description = "SSH access from admin IPs only"
   }
   
+  # HTTP/HTTPS remain public but with rate limiting in NGINX
   rule {
     direction  = "in"
     protocol   = "tcp"
@@ -46,20 +59,20 @@ resource "hcloud_firewall" "main" {
     source_ips = ["0.0.0.0/0", "::/0"]
   }
   
-  # Docker Swarm ports - Enhanced rules
+  # CHANGED: Docker Swarm restricted to specific node IPs only
   rule {
     direction  = "in"
     protocol   = "tcp"
     port       = "2377"
-    source_ips = ["10.0.0.0/16"]
-    description = "Docker Swarm manager API"
+    source_ips = ["10.0.1.10/32", "10.0.1.11/32", "10.0.1.12/32"]  # CHANGED: Specific IPs
+    description = "Docker Swarm manager - internal nodes only"
   }
   
   rule {
     direction  = "in"
     protocol   = "tcp"
     port       = "7946"
-    source_ips = ["10.0.0.0/16"]
+    source_ips = ["10.0.1.0/24"]  # CHANGED: Subnet restriction
     description = "Container network discovery"
   }
   
@@ -67,7 +80,7 @@ resource "hcloud_firewall" "main" {
     direction  = "in"
     protocol   = "udp"
     port       = "7946"
-    source_ips = ["10.0.0.0/16"]
+    source_ips = ["10.0.1.0/24"]  # CHANGED: Subnet restriction
     description = "Container network discovery"
   }
   
@@ -75,20 +88,116 @@ resource "hcloud_firewall" "main" {
     direction  = "in"
     protocol   = "udp"
     port       = "4789"
-    source_ips = ["10.0.0.0/16"]
+    source_ips = ["10.0.1.0/24"]  # CHANGED: Subnet restriction
     description = "Overlay network traffic"
   }
   
-  # Additional rule for ICMP (ping)
   rule {
     direction  = "in"
     protocol   = "icmp"
-    source_ips = ["10.0.0.0/16"]
+    source_ips = ["10.0.1.0/24"]  # CHANGED: Subnet restriction
     description = "Internal network ping"
+  }
+
+  # NEW: Egress rules for security
+  rule {
+    direction = "out"
+    protocol  = "tcp"
+    port      = "443"
+    destination_ips = ["0.0.0.0/0", "::/0"]
+    description = "HTTPS outbound for updates and Docker Hub"
+  }
+
+  # NEW: DNS egress
+  rule {
+    direction = "out"
+    protocol  = "udp"
+    port      = "53"
+    destination_ips = ["0.0.0.0/0", "::/0"]
+    description = "DNS resolution"
+  }
+
+  # NEW: NTP egress
+  rule {
+    direction = "out"
+    protocol  = "udp"
+    port      = "123"
+    destination_ips = ["0.0.0.0/0", "::/0"]
+    description = "NTP time sync"
+  }
+
+  # NEW: APT updates
+  rule {
+    direction = "out"
+    protocol  = "tcp"
+    port      = "80"
+    destination_ips = ["0.0.0.0/0", "::/0"]
+    description = "HTTP for APT updates"
+  }
+
+  # NEW: Block all other outbound traffic by default
+  apply_to = [
+    {
+      label_selector = "app=turbogate"
+    }
+  ]
+}
+
+# NEW: Bastion Host (optional but recommended)
+resource "hcloud_server" "bastion" {
+  count       = var.enable_bastion ? 1 : 0
+  name        = "turbogate-bastion"
+  image       = "ubuntu-22.04"
+  server_type = "cx11"  # Small instance
+  location    = var.location
+  ssh_keys    = [hcloud_ssh_key.default.id]
+
+  firewall_ids = [hcloud_firewall.bastion[0].id]
+
+  user_data = <<-EOF
+    #!/bin/bash
+    apt-get update
+    apt-get install -y fail2ban ufw
+
+    # Configure fail2ban
+    cat > /etc/fail2ban/jail.local <<-EOC
+    [sshd]
+    enabled = true
+    maxretry = 3
+    bantime = 3600
+    EOC
+
+    systemctl enable fail2ban
+    systemctl start fail2ban
+
+    # Configure UFW
+    ufw default deny incoming
+    ufw default allow outgoing
+    ufw allow from ${join(" ", var.admin_ips)} to any port 22
+    ufw --force enable
+  EOF
+
+  labels = {
+    role = "bastion"
+    app  = "turbogate"
   }
 }
 
-# Manager Node - Enhanced user_data for Docker Swarm
+# NEW: Bastion-specific firewall
+resource "hcloud_firewall" "bastion" {
+  count = var.enable_bastion ? 1 : 0
+  name = "turbogate-bastion-firewall"
+
+  rule {
+    direction  = "in"
+    protocol   = "tcp"
+    port       = "22"
+    source_ips = var.admin_ips
+    description = "SSH from admin IPs"
+  }
+}
+
+# Manager Node - SECURITY ENHANCED
 resource "hcloud_server" "manager" {
   name        = "turbogate-manager"
   image       = "ubuntu-22.04"
@@ -104,19 +213,121 @@ resource "hcloud_server" "manager" {
   
   user_data = <<-EOF
     #!/bin/bash
+    set -e
+
+    # Update system
     apt-get update
-    apt-get install -y python3 python3-pip net-tools
+    DEBIAN_FRONTEND=noninteractive apt-get upgrade -y
 
-    # Harden SSH configuration
-    sed -i 's/^#?PermitRootLogin.*/PermitRootLogin prohibit-password/' /etc/ssh/sshd_config
-    sed -i 's/^#?PasswordAuthentication.*/PasswordAuthentication no/' /etc/ssh/sshd_config
+    # Install security tools
+    apt-get install -y python3 python3-pip net-tools fail2ban aide rkhunter lynis unattended-upgrades
 
-    # Restart SSH service to apply changes
-    systemctl restart sshd
+    # NEW: Create non-root user for deployment
+    useradd -m -s /bin/bash -G sudo deploy
+    echo "deploy ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/deploy
 
+    # NEW: Copy SSH keys to deploy user
+    mkdir -p /home/deploy/.ssh
+    cp /root/.ssh/authorized_keys /home/deploy/.ssh/
+    chown -R deploy:deploy /home/deploy/.ssh
+    chmod 700 /home/deploy/.ssh
+    chmod 600 /home/deploy/.ssh/authorized_keys
+
+    # NEW: Harden SSH
+    cat > /etc/ssh/sshd_config.d/99-hardening.conf <<-SSC
+    PermitRootLogin no
+    PasswordAuthentication no
+    PubkeyAuthentication yes
+    MaxAuthTries 3
+    MaxSessions 2
+    ClientAliveInterval 300
+    ClientAliveCountMax 2
+    AllowUsers deploy
+    Protocol 2
+    X11Forwarding no
+    PermitEmptyPasswords no
+    ChallengeResponseAuthentication no
+    UsePAM yes
+    SSC
+
+    # NEW: Configure fail2ban
+    cat > /etc/fail2ban/jail.local <<-FBC
+    [DEFAULT]
+    bantime = 3600
+    findtime = 600
+    maxretry = 3
+
+    [sshd]
+    enabled = true
+    port = 22
+    filter = sshd
+    logpath = /var/log/auth.log
+    FBC
+
+    # NEW: Enable automatic security updates
+    cat > /etc/apt/apt.conf.d/50unattended-upgrades <<-UAC
+    Unattended-Upgrade::Allowed-Origins {
+        "\${distro_id}:\${distro_codename}-security";
+    };
+    Unattended-Upgrade::AutoFixInterruptedDpkg "true";
+    Unattended-Upgrade::MinimalSteps "true";
+    Unattended-Upgrade::Remove-Unused-Kernel-Packages "true";
+    Unattended-Upgrade::Remove-Unused-Dependencies "true";
+    Unattended-Upgrade::Automatic-Reboot "false";
+    UAC
+
+    # NEW: Configure kernel security parameters
+    cat >> /etc/sysctl.d/99-security.conf <<-KSC
+    # IP Spoofing protection
+    net.ipv4.conf.all.rp_filter = 1
+    net.ipv4.conf.default.rp_filter = 1
+
+    # Ignore ICMP redirects
+    net.ipv4.conf.all.accept_redirects = 0
+    net.ipv6.conf.all.accept_redirects = 0
+
+    # Ignore send redirects
+    net.ipv4.conf.all.send_redirects = 0
+
+    # Disable source packet routing
+    net.ipv4.conf.all.accept_source_route = 0
+    net.ipv6.conf.all.accept_source_route = 0
+
+    # Log Martians
+    net.ipv4.conf.all.log_martians = 1
+
+    # Ignore ICMP ping requests
+    net.ipv4.icmp_echo_ignore_broadcasts = 1
+
+    # Ignore Directed pings
+    net.ipv4.icmp_ignore_bogus_error_responses = 1
+
+    # Enable TCP/IP SYN cookies
+    net.ipv4.tcp_syncookies = 1
+    net.ipv4.tcp_max_syn_backlog = 2048
+    net.ipv4.tcp_synack_retries = 2
+    net.ipv4.tcp_syn_retries = 5
+
+    # Disable IPv6 if not needed
+    net.ipv6.conf.all.disable_ipv6 = 1
+    net.ipv6.conf.default.disable_ipv6 = 1
+    KSC
+
+    # Apply sysctl settings
+    sysctl -p /etc/sysctl.d/99-security.conf
+
+    # Add hosts entries
     echo "10.0.1.10 turbogate-manager" >> /etc/hosts
     echo "10.0.1.11 turbogate-worker-1" >> /etc/hosts
     echo "10.0.1.12 turbogate-worker-2" >> /etc/hosts
+
+    # NEW: Initialize AIDE (file integrity monitoring)
+    aideinit
+
+    # Restart SSH with new config
+    systemctl restart sshd
+    systemctl enable fail2ban
+    systemctl start fail2ban
   EOF
   
   labels = {
@@ -142,19 +353,103 @@ resource "hcloud_server" "worker" {
   
   user_data = <<-EOF
     #!/bin/bash
+    set -e
+
+    # Update system
     apt-get update
-    apt-get install -y python3 python3-pip net-tools
+    DEBIAN_FRONTEND=noninteractive apt-get upgrade -y
 
-    # Harden SSH configuration
-    sed -i 's/^#?PermitRootLogin.*/PermitRootLogin prohibit-password/' /etc/ssh/sshd_config
-    sed -i 's/^#?PasswordAuthentication.*/PasswordAuthentication no/' /etc/ssh/sshd_config
+    # Install security tools
+    apt-get install -y python3 python3-pip net-tools fail2ban aide rkhunter lynis unattended-upgrades
 
-    # Restart SSH service to apply changes
-    systemctl restart sshd
+    # Create non-root user
+    useradd -m -s /bin/bash -G sudo deploy
+    echo "deploy ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/deploy
 
+    # Copy SSH keys to deploy user
+    mkdir -p /home/deploy/.ssh
+    cp /root/.ssh/authorized_keys /home/deploy/.ssh/
+    chown -R deploy:deploy /home/deploy/.ssh
+    chmod 700 /home/deploy/.ssh
+    chmod 600 /home/deploy/.ssh/authorized_keys
+
+    # Harden SSH (same config as manager)
+    cat > /etc/ssh/sshd_config.d/99-hardening.conf <<-SSC
+    PermitRootLogin no
+    PasswordAuthentication no
+    PubkeyAuthentication yes
+    MaxAuthTries 3
+    MaxSessions 2
+    ClientAliveInterval 300
+    ClientAliveCountMax 2
+    AllowUsers deploy
+    Protocol 2
+    X11Forwarding no
+    PermitEmptyPasswords no
+    ChallengeResponseAuthentication no
+    UsePAM yes
+    SSC
+
+    # Configure fail2ban
+    cat > /etc/fail2ban/jail.local <<-FBC
+    [DEFAULT]
+    bantime = 3600
+    findtime = 600
+    maxretry = 3
+
+    [sshd]
+    enabled = true
+    port = 22
+    filter = sshd
+    logpath = /var/log/auth.log
+    FBC
+
+    # Enable automatic security updates
+    cat > /etc/apt/apt.conf.d/50unattended-upgrades <<-UAC
+    Unattended-Upgrade::Allowed-Origins {
+        "\${distro_id}:\${distro_codename}-security";
+    };
+    Unattended-Upgrade::AutoFixInterruptedDpkg "true";
+    Unattended-Upgrade::MinimalSteps "true";
+    Unattended-Upgrade::Remove-Unused-Kernel-Packages "true";
+    Unattended-Upgrade::Remove-Unused-Dependencies "true";
+    Unattended-Upgrade::Automatic-Reboot "false";
+    UAC
+
+    # Configure kernel security parameters (same as manager)
+    cat >> /etc/sysctl.d/99-security.conf <<-KSC
+    net.ipv4.conf.all.rp_filter = 1
+    net.ipv4.conf.default.rp_filter = 1
+    net.ipv4.conf.all.accept_redirects = 0
+    net.ipv6.conf.all.accept_redirects = 0
+    net.ipv4.conf.all.send_redirects = 0
+    net.ipv4.conf.all.accept_source_route = 0
+    net.ipv6.conf.all.accept_source_route = 0
+    net.ipv4.conf.all.log_martians = 1
+    net.ipv4.icmp_echo_ignore_broadcasts = 1
+    net.ipv4.icmp_ignore_bogus_error_responses = 1
+    net.ipv4.tcp_syncookies = 1
+    net.ipv4.tcp_max_syn_backlog = 2048
+    net.ipv4.tcp_synack_retries = 2
+    net.ipv4.tcp_syn_retries = 5
+    net.ipv6.conf.all.disable_ipv6 = 1
+    net.ipv6.conf.default.disable_ipv6 = 1
+    KSC
+
+    sysctl -p /etc/sysctl.d/99-security.conf
+
+    # Add hosts entries
     echo "10.0.1.10 turbogate-manager" >> /etc/hosts
     echo "10.0.1.11 turbogate-worker-1" >> /etc/hosts
     echo "10.0.1.12 turbogate-worker-2" >> /etc/hosts
+
+    # Initialize AIDE
+    aideinit
+
+    # Restart services
+    systemctl restart sshd
+    systemctl enable fail2ban
+    systemctl start fail2ban
   EOF
   
   labels = {
@@ -176,13 +471,15 @@ resource "hcloud_floating_ip_assignment" "main" {
   server_id      = hcloud_server.manager.id
 }
 
-# Generate Ansible inventory
+# CHANGED: Updated inventory to use deploy user
 resource "local_file" "ansible_inventory" {
   content = templatefile("${path.module}/../ansible/inventory/inventory.tpl", {
     manager_ip   = hcloud_server.manager.ipv4_address
     worker_1_ip  = hcloud_server.worker[0].ipv4_address
     worker_2_ip  = hcloud_server.worker[1].ipv4_address
     floating_ip  = hcloud_floating_ip.main.ip_address
+    ssh_user     = "deploy"  # NEW: Use deploy user
+    bastion_ip   = var.enable_bastion ? hcloud_server.bastion[0].ipv4_address : ""
   })
   filename = "${path.module}/../ansible/inventory/production.yml"
 }

--- a/deployment/terraform/main.tf
+++ b/deployment/terraform/main.tf
@@ -106,6 +106,14 @@ resource "hcloud_server" "manager" {
     #!/bin/bash
     apt-get update
     apt-get install -y python3 python3-pip net-tools
+
+    # Harden SSH configuration
+    sed -i 's/^#?PermitRootLogin.*/PermitRootLogin prohibit-password/' /etc/ssh/sshd_config
+    sed -i 's/^#?PasswordAuthentication.*/PasswordAuthentication no/' /etc/ssh/sshd_config
+
+    # Restart SSH service to apply changes
+    systemctl restart sshd
+
     echo "10.0.1.10 turbogate-manager" >> /etc/hosts
     echo "10.0.1.11 turbogate-worker-1" >> /etc/hosts
     echo "10.0.1.12 turbogate-worker-2" >> /etc/hosts
@@ -136,6 +144,14 @@ resource "hcloud_server" "worker" {
     #!/bin/bash
     apt-get update
     apt-get install -y python3 python3-pip net-tools
+
+    # Harden SSH configuration
+    sed -i 's/^#?PermitRootLogin.*/PermitRootLogin prohibit-password/' /etc/ssh/sshd_config
+    sed -i 's/^#?PasswordAuthentication.*/PasswordAuthentication no/' /etc/ssh/sshd_config
+
+    # Restart SSH service to apply changes
+    systemctl restart sshd
+
     echo "10.0.1.10 turbogate-manager" >> /etc/hosts
     echo "10.0.1.11 turbogate-worker-1" >> /etc/hosts
     echo "10.0.1.12 turbogate-worker-2" >> /etc/hosts

--- a/deployment/terraform/outputs.tf
+++ b/deployment/terraform/outputs.tf
@@ -1,21 +1,17 @@
-output "manager_ip" {
-  value = hcloud_server.manager.ipv4_address
+output "all_network_ips" {
+  value = {
+    manager_public = hcloud_server.manager.ipv4_address
+    manager_internal = [for net in hcloud_server.manager.network : net.ip][0]
+    workers_public = [for s in hcloud_server.worker : s.ipv4_address]
+    workers_internal = [for s in hcloud_server.worker : [for net in s.network : net.ip][0]]
+    bastion_public = var.enable_bastion ? hcloud_server.bastion[0].ipv4_address : null
+  }
+  description = "All network IPs for verification"
+  sensitive = true  # NEW: Mark as sensitive
 }
 
 output "floating_ip" {
   value = hcloud_floating_ip.main.ip_address
-}
-
-output "worker_ips" {
-  value = [for s in hcloud_server.worker : s.ipv4_address]
-}
-
-output "internal_network" {
-  value = {
-    manager = [for net in hcloud_server.manager.network : net.ip][0]
-    workers = [for s in hcloud_server.worker : [for net in s.network : net.ip][0]]
-  }
-  description = "Internal network IPs"
 }
 
 output "inventory_file_path" {

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -29,3 +29,16 @@ variable "domain_name" {
   default     = "turbogate.app"
 }
 
+variable "admin_ips" {
+  description = "List of admin IP addresses for SSH access"
+  type        = list(string)
+  default = [
+    "YOUR_IP_HERE/32" # <-- Add your IP here
+  ]
+}
+
+variable "enable_bastion" {
+  description = "Enable a bastion host for secure access"
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
feat(security): Comprehensive security hardening
This commit introduces a comprehensive set of security hardening measures across the entire infrastructure, from the network layer to the application configuration.

Key changes include:

- **Dynamic IP Whitelisting:** The Terraform configuration now dynamically fetches the latest IP ranges for GitHub Actions from the GitHub API and uses them to configure the firewall. This ensures that the CI/CD pipeline always has access.

- **Firewall Hardening:**
  - Implements restrictive firewall rules with egress controls.
  - Restricts SSH access to a list of admin IPs and the dynamically fetched GitHub Actions IPs.

- **Bastion Host:**
  - Adds an optional bastion host for more secure SSH access, which can be enabled via the `enable_bastion` variable.

- **Server Hardening:**
  - Updates the `user_data` script for all servers to:
    - Disable root login and password authentication for SSH.
    - Create a non-root `deploy` user for Ansible.
    - Install and configure Fail2Ban, AIDE, RKHunter, and unattended-upgrades.
    - Harden kernel parameters using `sysctl`.

- **Deployment Pipeline:**
  - Integrates the Fail2Ban setup into the CD pipeline in `.github/workflows/cd.yml`.

- **NGINX Hardening:**
  - Hides the NGINX server version by setting `server_tokens off;`.

- **Ansible Inventory:**
  - Updates the Ansible inventory template to use the new `deploy` user and support the bastion host.
