### PR TITLE
feat: add unattended upgrades and fail2ban configuration templates

### DIFF
--- a/deployment/ansible/playbooks/templates/50unattended-upgrades.j2
+++ b/deployment/ansible/playbooks/templates/50unattended-upgrades.j2
@@ -1,0 +1,51 @@
+
+Unattended-Upgrade::Allowed-Origins {
+    "${distro_id}:${distro_codename}";
+    "${distro_id}:${distro_codename}-security";
+    "${distro_id}ESMApps:${distro_codename}-apps-security";
+    "${distro_id}ESM:${distro_codename}-infra-security";
+};
+
+// Automatically upgrade packages from these repositories
+Unattended-Upgrade::Package-Whitelist {
+    // Security updates are always allowed
+};
+
+// Do NOT automatically upgrade these packages
+Unattended-Upgrade::Package-Blacklist {
+    // Prevent Docker from auto-updating to avoid breaking changes
+    "docker-ce";
+    "docker-ce-cli";
+    "containerd.io";
+    // Prevent kernel updates that require reboot
+    "linux-image.*";
+    "linux-headers.*";
+    "linux-modules.*";
+};
+
+// Automatically remove unused kernel packages
+Unattended-Upgrade::Remove-Unused-Kernel-Packages "{{ remove_unused_kernels | default('true') }}";
+
+// Remove unused dependencies
+Unattended-Upgrade::Remove-New-Unused-Dependencies "true";
+Unattended-Upgrade::Remove-Unused-Dependencies "{{ remove_unused_deps | default('true') }}";
+
+// Reboot settings
+Unattended-Upgrade::Automatic-Reboot "{{ automatic_reboot | default('false') }}";
+Unattended-Upgrade::Automatic-Reboot-WithUsers "false";
+Unattended-Upgrade::Automatic-Reboot-Time "{{ reboot_time | default('02:00') }}";
+
+// Email notifications
+Unattended-Upgrade::Mail "{{ notification_email | default('root') }}";
+Unattended-Upgrade::MailReport "{{ mail_report | default('on-change') }}";
+
+// Logging
+Unattended-Upgrade::SyslogEnable "true";
+Unattended-Upgrade::SyslogFacility "daemon";
+
+// Download and install upgrades
+Unattended-Upgrade::MinimalSteps "true";
+Unattended-Upgrade::InstallOnShutdown "false";
+
+// Bandwidth and timing
+Unattended-Upgrade::Skip-Updates-On-Metered-Connections "true";

--- a/deployment/ansible/playbooks/templates/jail.local.j2
+++ b/deployment/ansible/playbooks/templates/jail.local.j2
@@ -1,0 +1,79 @@
+[DEFAULT]
+# Ban IP for this duration (in seconds)
+bantime = {{ fail2ban_bantime | default(3600) }}
+
+# Time window to count failures
+findtime = {{ fail2ban_findtime | default(600) }}
+
+# Number of failures before ban
+maxretry = {{ fail2ban_maxretry | default(5) }}
+
+# IPs to never ban (internal networks)
+ignoreip = 127.0.0.1/8 10.0.0.0/16 ::1
+
+# Backend for log monitoring
+backend = systemd
+
+# Log settings
+loglevel = INFO
+logtarget = /var/log/fail2ban.log
+
+# Ban action
+banaction = iptables-multiport
+banaction_allports = iptables-allports
+
+#
+# JAILS
+#
+
+[sshd]
+enabled = true
+port = ssh
+filter = sshd
+logpath = /var/log/auth.log
+maxretry = {{ ssh_maxretry | default(3) }}
+bantime = {{ fail2ban_bantime | default(3600) }}
+
+[sshd-ddos]
+enabled = true
+port = ssh
+filter = sshd-ddos
+logpath = /var/log/auth.log
+maxretry = 2
+bantime = 86400
+
+{% if 'swarm_managers' in group_names %}
+# nginx jails (only for manager nodes)
+[nginx-http-auth]
+enabled = true
+filter = nginx-http-auth
+port = http,https
+logpath = /var/log/turbogate/nginx/*access.log
+maxretry = 5
+bantime = 3600
+
+[nginx-limit-req]
+enabled = true
+filter = nginx-limit-req
+port = http,https
+logpath = /var/log/turbogate/nginx/*error.log
+maxretry = 10
+bantime = 1800
+
+[nginx-404]
+enabled = true
+port = http,https
+filter = nginx-404
+logpath = /var/log/turbogate/nginx/*access.log
+bantime = 3600
+maxretry = 20
+findtime = 600
+{% endif %}
+
+# Port scanning protection (all nodes)
+[portscan]
+enabled = true
+filter = portscan
+logpath = /var/log/syslog
+maxretry = 6
+bantime = 86400


### PR DESCRIPTION
- Purpose: Create reusable templates for fail2ban and automatic security updates

Key features:

- Conditional nginx rules: Only manager nodes get web-related fail2ban rules

- Automatic security updates: Critical security patches applied automatically, but Docker/kernel updates are blocked to prevent breaking changes

- Network awareness: Internal networks (10.0.0.0/16) are never banned

- Role-specific configuration: Different rules for different server types