### PR TITLE
fix(deploy): Correct service configurations to prevent restart loops

### DIFF
--- a/deployment/ansible/playbooks/templates/docker-compose-waf.yml.j2
+++ b/deployment/ansible/playbooks/templates/docker-compose-waf.yml.j2
@@ -32,7 +32,7 @@ services:
       - "--providers.swarm.endpoint=unix:///var/run/docker.sock"
       - "--providers.swarm.watch=true"
       - "--providers.swarm.exposedbydefault=false"
-      - "--providers.swarm.network=turbogate_traefik_proxy"
+      - "--providers.swarm.network=traefik_proxy"
       # Observability
       - "--log.level=INFO"
       - "--accesslog=true"
@@ -177,7 +177,7 @@ services:
     cap_add:
       - NET_BIND_SERVICE
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:80/gateway/health"]
+      test: ["CMD", "curl", "-f", "http://localhost:8080/gateway/health"]
       interval: 15s
       timeout: 5s
       retries: 3


### PR DESCRIPTION
This commit fixes two critical misconfigurations in the Docker Compose template that caused the `traefik` and `modsecurity` services to fail their healthchecks and enter a restart loop.

1.  **Correct `modsecurity` healthcheck port:** The `modsecurity` service is configured to listen on port 8080 via the `PORT` environment variable. The healthcheck was incorrectly targeting port 80. This has been corrected to point to port 8080.

2.  **Correct `traefik` provider network name:** The `traefik` service was configured to monitor the Docker Swarm network `turbogate_traefik_proxy` for service discovery. However, the network is created and referenced in the compose file as `traefik_proxy`. This has been corrected to use the proper network name, allowing Traefik to discover other services and its own healthcheck endpoint.

These changes ensure that the services can pass their healthchecks and remain stable after deployment.