### PR TITLE
fix: The Traefik service was in a restart loop due to a failing healthcheck.

### DIFF
--- a/deployment/ansible/playbooks/templates/docker-compose-waf.yml.j2
+++ b/deployment/ansible/playbooks/templates/docker-compose-waf.yml.j2
@@ -92,7 +92,7 @@ services:
     cap_add:
       - NET_BIND_SERVICE
     healthcheck:
-      test: ["CMD", "traefik", "healthcheck", "--ping", "--ping-entrypoint=web"]
+      test: ["CMD", "curl", "-f", "http://localhost:80/ping"]
       interval: 15s
       timeout: 5s
       retries: 3


### PR DESCRIPTION
The healthcheck was using the `traefik healthcheck` command, which is deprecated in Traefik v3.

This change replaces the deprecated command with a `curl` command to check the `/ping` endpoint directly. This is the recommended way to perform healthchecks for Traefik v3 and will resolve the restart loop issue.