### PR TITLE
fix(deploy): Correct backend hostname for modsecurity

### DIFF
--- a/deployment/ansible/playbooks/templates/docker-compose-waf.yml.j2
+++ b/deployment/ansible/playbooks/templates/docker-compose-waf.yml.j2
@@ -102,8 +102,8 @@ services:
     image: owasp/modsecurity-crs:apache
     environment:
       PARANOIA: "{{ modsec_paranoia_level | default(1) }}"
-      BACKEND: "http://turbogate_turbogate:5000"
-      BACKEND_WS: "ws://turbogate_turbogate:5000"
+      BACKEND: "http://turbogate:5000"
+      BACKEND_WS: "ws://turbogate:5000"
       PORT: "8080"
       SSL_ENGINE: "off"
       MODSEC_AUDIT_LOG: "/dev/stdout"


### PR DESCRIPTION
The modsecurity service was failing to resolve the `turbogate` service due to an incorrect hostname in its configuration. The `BACKEND` environment variable was set to `http://turbogate_turbogate:5000`, which is not the correct service name for inter-service communication within the Docker Swarm stack.

This change corrects the hostname to `http://turbogate:5000`, which is the proper service name as defined in the Docker Compose file. This allows the `modsecurity` service to correctly resolve and proxy requests to the `turbogate` application.