### PR TITLE
fix: Fix Docker Swarm deployment issues

### DIFF
--- a/deployment/ansible/playbooks/setup_swarm.yml
+++ b/deployment/ansible/playbooks/setup_swarm.yml
@@ -270,9 +270,9 @@
           role: "{{ 'manager' if 'swarm_managers' in group_names else 'worker' }}"
           app: "turbogate"
           environment: "production"
-          security_hardened: "{{ node_security_enabled | string }}"
+          security_hardened: "{{ node_security_enabled | string | lower }}"
           security_zone: "{{ 'dmz' if 'swarm_managers' in group_names else ('database' if ansible_hostname.endswith('-3') else 'internal') }}"
-          fail2ban_enabled: "{{ node_security_enabled | string }}"
+          fail2ban_enabled: "{{ node_security_enabled | string | lower }}"
           network_segment: "{{ 'management' if 'swarm_managers' in group_names else 'application' }}"
       delegate_to: "{{ groups['swarm_managers'][0] }}"
 

--- a/deployment/ansible/playbooks/templates/docker-compose-waf.yml.j2
+++ b/deployment/ansible/playbooks/templates/docker-compose-waf.yml.j2
@@ -2,12 +2,15 @@ version: '3.8'
 
 services:
   traefik:
-    image: traefik:v3.4
+    image: traefik:v3.1.1
     networks:
       - traefik_proxy
     ports:
       - target: 80
         published: 80
+        protocol: tcp
+      - target: 8080
+        published: 8080
         protocol: tcp
     configs:
       - source: traefik_tls_config_v{{ resource_version }}
@@ -388,12 +391,17 @@ services:
           memory: 64M
     entrypoint: ["/bin/sh", "-c"]
     command: |
+      echo "Waiting for redis-master to be available..."
+      while ! redis-cli -h redis-master -p 6379 -a "$$(cat /run/secrets/redis_password)" ping; do
+        sleep 1
+      done
+      echo "Redis-master is available. Starting sentinel."
       echo "port 26379
       sentinel monitor mymaster redis-master 6379 2
       sentinel auth-pass mymaster $$(cat /run/secrets/redis_password)
       sentinel down-after-milliseconds mymaster 5000
       sentinel failover-timeout mymaster 10000
-      sentinel parallel-syncs mymaster 1" > /tmp/sentinel.conf && 
+      sentinel parallel-syncs mymaster 1" > /tmp/sentinel.conf &&
       redis-sentinel /tmp/sentinel.conf
     user: "999:999"
     tmpfs:


### PR DESCRIPTION
This commit fixes several issues in the Docker Swarm deployment configuration that were preventing the `traefik` and `redis-sentinel` services from starting correctly.

The following changes were made:

- **Traefik Configuration:**
  - Downgraded the Traefik image from `v3.4` to `v3.1.1` to use a more stable version.
  - Exposed port `8080` for the Traefik API and dashboard.

- **Redis Sentinel Startup:**
  - Modified the `redis-sentinel` service command to wait for `redis-master` to be available before starting. This fixes a race condition that was causing the sentinel to fail on startup.

- **Node Labels:**
  - Standardized the `security_hardened` and `fail2ban_enabled` node labels in the `setup_swarm.yml` Ansible playbook to be lowercase strings (`true`/`false`). This fixes inconsistencies that could cause services with placement constraints to fail scheduling.